### PR TITLE
Update signers in unit tests to testate signers with private key

### DIFF
--- a/chains/docker-compose.yml
+++ b/chains/docker-compose.yml
@@ -11,8 +11,8 @@ services:
             /home/openethereum/.local/share/openethereum/chain1-data  --keys-path
             /home/openethereum/.local/share/openethereum/keys --tracing on
         ports:
-            - 9550:8545
-            - 9551:8546
+            - 9545:8545
+            - 9546:8546
             - 30303:30303
             - 30303:30303/udp
     chain2:
@@ -26,7 +26,7 @@ services:
             /home/openethereum/.local/share/openethereum/chain2-data  --keys-path
             /home/openethereum/.local/share/openethereum/keys --tracing on
         ports:
-            - 9552:8545
-            - 9553:8546
+            - 9545:8545
+            - 9546:8546
             - 30304:30303
             - 30304:30303/udp

--- a/chains/docker-compose.yml
+++ b/chains/docker-compose.yml
@@ -11,8 +11,8 @@ services:
             /home/openethereum/.local/share/openethereum/chain1-data  --keys-path
             /home/openethereum/.local/share/openethereum/keys --tracing on
         ports:
-            - 9545:8545
-            - 9546:8546
+            - 9550:8545
+            - 9551:8546
             - 30303:30303
             - 30303:30303/udp
     chain2:
@@ -26,7 +26,7 @@ services:
             /home/openethereum/.local/share/openethereum/chain2-data  --keys-path
             /home/openethereum/.local/share/openethereum/keys --tracing on
         ports:
-            - 9545:8545
-            - 9546:8546
+            - 9552:8545
+            - 9553:8546
             - 30304:30303
             - 30304:30303/udp

--- a/evaluation/get-mt-for-map-sizes-1-1000.ts
+++ b/evaluation/get-mt-for-map-sizes-1-1000.ts
@@ -37,8 +37,8 @@ describe('get-mt-for-map-sizes-1-1000', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'get-mt-for-map-sizes-1-1000.ts' });
     });
 

--- a/evaluation/update-multiple-deep-values-with-map-sizes-1-1000.ts
+++ b/evaluation/update-multiple-deep-values-with-map-sizes-1-1000.ts
@@ -41,8 +41,8 @@ describe('update-multiple-values-with-map-sizes-1-1000', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'update-multiple-deep-values-with-map-sizes-1-1000.ts' });
         csvManager = new CSVManager<CSVDataTemplateMultipleValues>('measurements-multiple-deep-values-with-map-sizes-1-to-1000.csv');
         differ = new DiffHandler(srcProvider, targetProvider);

--- a/evaluation/update-multiple-values-random-with-map-sizes-1-1000.ts
+++ b/evaluation/update-multiple-values-random-with-map-sizes-1-1000.ts
@@ -41,8 +41,8 @@ describe('update-multiple-values-random-with-map-sizes-1-1000', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'update-multiple-values-random-with-map-sizes-1-1000.ts' });
         csvManager = new CSVManager<CSVDataTemplateMultipleValues>('measurements-multiple-values-random-with-map-sizes-1-1000.csv');
         differ = new DiffHandler(srcProvider, targetProvider);

--- a/evaluation/update-one-value-per-mpt-height-with-map-sizes-1-to-1000.ts
+++ b/evaluation/update-one-value-per-mpt-height-with-map-sizes-1-to-1000.ts
@@ -42,8 +42,8 @@ describe('update-one-value-per-mpt-height-with-map-sizes-1-to-1000', async () =>
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'update-one-value-per-mpt-height-with-map-sizes-1-to-1000.ts' });
         csvManager = new CSVManager<CSVDataTemplatePerMTHeight>('measurements-update-one-value-per-mpt-height-with-map-sizes-1-to-1000.csv');
         differ = new DiffHandler(srcProvider, targetProvider);

--- a/evaluation/update-one-value-with-map-sizes-1-1000.ts
+++ b/evaluation/update-one-value-with-map-sizes-1-1000.ts
@@ -42,8 +42,8 @@ describe('update-one-value-with-map-sizes-1-1000', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'update-one-value-with-map-sizes-1-1000.ts' });
         csvManager = new CSVManager<CSVDataTemplateSingleValue>('measurements-update-one-value-with-map-sizes-1-to-1000.csv');
         differ = new DiffHandler(srcProvider, targetProvider);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,9 @@ import { task } from "hardhat/config";
 import "@nomiclabs/hardhat-waffle";
 import "@openzeppelin/hardhat-upgrades";
 import "@typechain/hardhat";
+import * as dotenv from "dotenv";
+
+dotenv.config();
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html
@@ -34,6 +37,18 @@ export default {
         url: "http://127.0.0.1:8547",
         gas: 1000000000,
         timeout: 3600000
+    },
+    goerli: {
+      url: process.env.RPC_URL_GOERLI,
+      accounts: [`0x${process.env.PRIVATE_KEY}`],
+    },
+    polygon_mumbai: {
+      url: process.env.RPC_URL_MUMBAI,
+      accounts: [`0x${process.env.PRIVATE_KEY}`],
+    },
+    gnosis_testnet: {
+      url: process.env.RPC_URL_GNOSIS_TESTNET,
+      accounts: [`0x${process.env.PRIVATE_KEY}`],
     }
   },
   typechain: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "smart-sync",
       "version": "0.3.4",
       "license": "GPL-3.0",
       "dependencies": {
@@ -22,6 +23,7 @@
         "commander": "^8.3.0",
         "csv-parse": "^5.0.4",
         "csv-stringify": "^6.0.5",
+        "dotenv": "^16.0.3",
         "ethers": "^5.5.2",
         "hardhat": "^2.8.0",
         "merkle-patricia-tree": "^4.2.2",
@@ -4639,6 +4641,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
@@ -29919,6 +29929,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dynamic-dedupe": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commander": "^8.3.0",
     "csv-parse": "^5.0.4",
     "csv-stringify": "^6.0.5",
+    "dotenv": "^16.0.3",
     "ethers": "^5.5.2",
     "hardhat": "^2.8.0",
     "merkle-patricia-tree": "^4.2.2",

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -47,14 +47,8 @@ describe('Test CLI', async () => {
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs?.targetChainRpcUrl || TestCLI.DEFAULT_PROVIDER, timeout: BigNumber.from(chainConfigs?.connectionTimeout).toNumber() });
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs?.srcChainRpcUrl || TestCLI.DEFAULT_PROVIDER, timeout: BigNumber.from(chainConfigs?.connectionTimeout).toNumber() });
         differ = new DiffHandler(srcProvider, targetProvider);
-
-        const targetSigner = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider);
-        const srcSigner = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider);
-        targetSigner.connect(targetProvider);
-        srcSigner.connect(srcProvider);
-
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
         factory = new MappingContract__factory(srcDeployer);
     });
 

--- a/test/cli-test.ts
+++ b/test/cli-test.ts
@@ -47,6 +47,12 @@ describe('Test CLI', async () => {
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs?.targetChainRpcUrl || TestCLI.DEFAULT_PROVIDER, timeout: BigNumber.from(chainConfigs?.connectionTimeout).toNumber() });
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs?.srcChainRpcUrl || TestCLI.DEFAULT_PROVIDER, timeout: BigNumber.from(chainConfigs?.connectionTimeout).toNumber() });
         differ = new DiffHandler(srcProvider, targetProvider);
+
+        const targetSigner = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider);
+        const srcSigner = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider);
+        targetSigner.connect(targetProvider);
+        srcSigner.connect(srcProvider);
+
         targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
         srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
         factory = new MappingContract__factory(srcDeployer);

--- a/test/config/test-cli-config.json
+++ b/test/config/test-cli-config.json
@@ -1,7 +1,7 @@
 {
-    "srcChainRpcUrl":"https://b28e91d2ad044ec0b1c89db096028236.goerli.rpc.rivet.cloud/",
+    "srcChainRpcUrl": "https://b28e91d2ad044ec0b1c89db096028236.goerli.rpc.rivet.cloud/",
     "targetChainRpcUrl": "https://polygon-mumbai.g.alchemy.com/v2/izk8roTk3konGfjDItgOyvlJJjXDa_cL",
-    "connectionTimeout": "36000",
+    "connectionTimeout": "66000",
     "logLevel": "info",
     "targetBlocknr": "latest",
     "gasLimit": 8000000,

--- a/test/config/test-cli-config.json
+++ b/test/config/test-cli-config.json
@@ -1,6 +1,6 @@
 {
-    "srcChainRpcUrl": "http://localhost:9550",
-    "targetChainRpcUrl": "http://localhost:9552",
+    "srcChainRpcUrl":"https://b28e91d2ad044ec0b1c89db096028236.goerli.rpc.rivet.cloud/",
+    "targetChainRpcUrl": "https://polygon-mumbai.g.alchemy.com/v2/izk8roTk3konGfjDItgOyvlJJjXDa_cL",
     "connectionTimeout": "36000",
     "logLevel": "info",
     "targetBlocknr": "latest",

--- a/test/extension-validation-test.ts
+++ b/test/extension-validation-test.ts
@@ -35,7 +35,7 @@ describe('Extension Validation', async () => {
         }
         logger.setSettings({ minLevel: 'info', name: 'extension-validation-test.ts' });
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
     });
 
     beforeEach(async () => {

--- a/test/get-diff-test.ts
+++ b/test/get-diff-test.ts
@@ -25,7 +25,7 @@ describe('Get contract storage diff', () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'get-diff-test.ts' });
     });
 

--- a/test/list-storage-test.ts
+++ b/test/list-storage-test.ts
@@ -23,7 +23,7 @@ describe('Storage', async () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'list-storage-test.ts' });
     });
 

--- a/test/log-delegate-test.ts
+++ b/test/log-delegate-test.ts
@@ -37,7 +37,7 @@ describe('Test static proxy calls', () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
     });
 
     it('Should deploy the contracts', async () => {

--- a/test/new-initialization-test.ts
+++ b/test/new-initialization-test.ts
@@ -34,8 +34,8 @@ describe('New Initialization', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'new-initialization.ts' });
     });
 

--- a/test/optimized-storage-proof-test.ts
+++ b/test/optimized-storage-proof-test.ts
@@ -22,7 +22,7 @@ describe('Test storage proof optimization', async () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         const Storage = new SimpleStorage__factory(deployer);
         storage = await Storage.deploy();
         logger.setSettings({ minLevel: 'info', name: 'optimized-storage-proof-test.ts' });

--- a/test/proof-path-builder-test.ts
+++ b/test/proof-path-builder-test.ts
@@ -25,7 +25,7 @@ describe('Proof Path Builder Tests', () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'proof-path-builder-test.ts' });
     });
 

--- a/test/proxy-deploy-test.ts
+++ b/test/proxy-deploy-test.ts
@@ -37,7 +37,7 @@ describe('Deploy proxy and logic contract', async () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'proxy-deploy-test.ts' });
     });
 

--- a/test/scale-test.ts
+++ b/test/scale-test.ts
@@ -37,8 +37,8 @@ describe('Test scaling of contract', async () => {
         }
         srcProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
         targetProvider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.targetChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        srcDeployer = await SignerWithAddress.create(srcProvider.getSigner());
-        targetDeployer = await SignerWithAddress.create(targetProvider.getSigner());
+        srcDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, srcProvider); // await SignerWithAddress.create(srcProvider.getSigner());
+        targetDeployer = new ethers.Wallet(process.env.PRIVATE_KEY, targetProvider); // await SignerWithAddress.create(targetProvider.getSigner());
         logger.setSettings({ minLevel: 'info', name: 'scale_test.ts' });
     });
 

--- a/test/state-proof-test.ts
+++ b/test/state-proof-test.ts
@@ -25,7 +25,7 @@ describe('Validate old contract state', () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
         const Storage = new SimpleStorage__factory(deployer);
         storage = await Storage.deploy();
     });

--- a/test/verify-proxy-test.ts
+++ b/test/verify-proxy-test.ts
@@ -23,7 +23,7 @@ describe('Verify State proof', () => {
             process.exit(-1);
         }
         provider = new ethers.providers.JsonRpcProvider({ url: chainConfigs.srcChainRpcUrl, timeout: BigNumber.from(chainConfigs.connectionTimeout).toNumber() });
-        deployer = await SignerWithAddress.create(provider.getSigner());
+        deployer = new ethers.Wallet(process.env.PRIVATE_KEY, provider); // await SignerWithAddress.create(provider.getSigner());
     });
 
     it('Should deploy and return default values', async () => {


### PR DESCRIPTION
Done
- Switched the way the signers are created to use the private key variable from the .env file. This allows transactions to be created on the testiest used, e.g., Goerli and Polygon Mumbai
- Switched the RPC URL of source and target networks to environment variables for the desired evm compatible testnets.
- Some transactions can be seen on Goerli and Mumbai after the unit tests are ran and there is an attempt to sync smart contracts on both networks but some tests are failing so investigating those
 
Pending
- Get all unit tests to pass on the testnets and not local simulated evm networks.